### PR TITLE
Removed customerType from group update_data

### DIFF
--- a/src/Entity/Tenant.php
+++ b/src/Entity/Tenant.php
@@ -85,7 +85,6 @@ class Tenant
      * @var string|null
      * @Serializer\SerializedName("customer_type")
      * @Serializer\Type("string")
-     * @Serializer\Groups({"create_data"})
      */
     private $customerType;
 
@@ -141,7 +140,6 @@ class Tenant
      * @var bool
      * @Serializer\SerializedName("ancestral_access")
      * @Serializer\Type("boolean")
-     * @Serializer\Groups({"create_data","update_data"})
      */
     private $ancestralAccess;
 

--- a/src/Entity/Tenant.php
+++ b/src/Entity/Tenant.php
@@ -85,7 +85,7 @@ class Tenant
      * @var string|null
      * @Serializer\SerializedName("customer_type")
      * @Serializer\Type("string")
-     * @Serializer\Groups({"create_data","update_data"})
+     * @Serializer\Groups({"create_data"})
      */
     private $customerType;
 

--- a/tests/Integration/Client/TenantClientTest.php
+++ b/tests/Integration/Client/TenantClientTest.php
@@ -154,6 +154,8 @@ class TenantClientTest extends TestCase
 
                 $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
                 $this->assertArrayNotHasKey('id', $decoded);
+                $this->assertArrayNotHasKey('customer_type', $decoded);
+                $this->assertArrayNotHasKey('ancestral_access', $decoded);
                 $this->assertArrayNotHasKey('created_at', $decoded);
                 $this->assertArrayNotHasKey('updated_at', $decoded);
                 $this->assertArrayNotHasKey('deleted_at', $decoded);
@@ -165,14 +167,12 @@ class TenantClientTest extends TestCase
                 $this->assertSame($tenant->getVersion(), $decoded['version']);
                 $this->assertSame($tenant->getName(), $decoded['name']);
                 $this->assertSame($tenant->getInternalTag(), $decoded['internal_tag']);
-                $this->assertSame($tenant->getCustomerType(), $decoded['customer_type']);
                 $this->assertSame($tenant->getMfaStatus(), $decoded['mfa_status']);
                 $this->assertSame($tenant->getKind(), $decoded['kind']);
                 $this->assertSame($tenant->getPricingMode(), $decoded['pricing_mode']);
                 $this->assertSame($tenant->getLanguage(), $decoded['language']);
                 $this->assertTrue($decoded['enabled']);
                 $this->assertTrue($decoded['has_children']);
-                $this->assertTrue($decoded['ancestral_access']);
 
                 /** @var Contact $contact */
                 $contact = $tenant->getContact();
@@ -235,6 +235,8 @@ class TenantClientTest extends TestCase
 
                 $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
                 $this->assertArrayHasKey('id', $decoded);
+                $this->assertArrayNotHasKey('customer_type', $decoded);
+                $this->assertArrayNotHasKey('ancestral_access', $decoded);
                 $this->assertArrayNotHasKey('created_at', $decoded);
                 $this->assertArrayNotHasKey('updated_at', $decoded);
                 $this->assertArrayNotHasKey('deleted_at', $decoded);


### PR DESCRIPTION
Changed by advisory of Acronis

> Hello George,
> 
> Thank you for your patience while our dev team looked into this.
> 
> We have managed to isolate this and an internal reference for it has been created.
> 
> The "customer_type" parameter is meant to be used by internal integration systems, and not for the outside use.
> 
> In this case our development team have advised not to use this field at all - default value would be set in this case which won't cause the same issue.
> 
> With the documentation of this it will be changed in the future to avoid this situation and misunderstanding.
> 
> Since the issue has been addressed, I was wondering if we can archive the case, unless you have any other questions of course?
> 
> Looking forward to hearing from you!
> 
> Best regards,
> George 
> Support Professional
> Acronis Service Provider Support Team
> 