### PR TITLE
fix SandwaveIo\Acronis\BearerTokenMiddleware::$bearerToken

### DIFF
--- a/src/BearerTokenMiddleware.php
+++ b/src/BearerTokenMiddleware.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\RequestInterface;
 
 class BearerTokenMiddleware
 {
-    private ?string $bearerToken;
+    private ?string $bearerToken = null;
 
     private string $url;
 


### PR DESCRIPTION
fix SandwaveIo\Acronis\BearerTokenMiddleware::$bearerToken must not be accessed before initialization